### PR TITLE
Upgrade PyTorch to 2.0 for ipadapter_FaceID

### DIFF
--- a/ipadapter_FaceID/README.md
+++ b/ipadapter_FaceID/README.md
@@ -105,9 +105,9 @@ cd Kolors
 conda create --name kolors python=3.8
 conda activate kolors
 pip install -r requirements.txt
-pip install insightface onnxruntime-gpu
 # Upgrade PyTorch to 2.0, for more versions see https://pytorch.org/
 pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+pip install insightface onnxruntime-gpu
 python3 setup.py install
 ```
 

--- a/ipadapter_FaceID/README.md
+++ b/ipadapter_FaceID/README.md
@@ -107,7 +107,7 @@ conda activate kolors
 pip install -r requirements.txt
 pip install insightface onnxruntime-gpu
 # Upgrade PyTorch to 2.0, for more versions see https://pytorch.org/
-pip3 install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 python3 setup.py install
 ```
 

--- a/ipadapter_FaceID/README.md
+++ b/ipadapter_FaceID/README.md
@@ -106,6 +106,8 @@ conda create --name kolors python=3.8
 conda activate kolors
 pip install -r requirements.txt
 pip install insightface onnxruntime-gpu
+# Upgrade PyTorch to 2.0, for more versions see https://pytorch.org/
+pip3 install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
 python3 setup.py install
 ```
 


### PR DESCRIPTION
In the PyTorch 1.13.1 version provided in `requirements.txt`, the following error is reported when executing the command.
```powershell
Traceback (most recent call last):
  File "ipadapter_FaceID/sample_ipadapter_faceid_plus.py", line 121, in <module>
    fire.Fire(infer)
  File "/root/miniconda3/envs/kolors/lib/python3.8/site-packages/fire/core.py", line 143, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/root/miniconda3/envs/kolors/lib/python3.8/site-packages/fire/core.py", line 477, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/root/miniconda3/envs/kolors/lib/python3.8/site-packages/fire/core.py", line 693, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "ipadapter_FaceID/sample_ipadapter_faceid_plus.py", line 85, in infer
    pipe.load_ip_adapter_faceid_plus(f'{ip_model_dir}/ipa-faceid-plus.bin', device = device)
  File "/root/miniconda3/envs/kolors/lib/python3.8/site-packages/kolors-0.1-py3.8.egg/kolors/pipelines/pipeline_stable_diffusion_xl_chatglm_256_ipadapter_FaceID.py", line 612, in load_ip_adapter_faceid_plus
    self.set_ip_adapter(num_tokens = 6, device = device)
  File "/root/miniconda3/envs/kolors/lib/python3.8/site-packages/kolors-0.1-py3.8.egg/kolors/pipelines/pipeline_stable_diffusion_xl_chatglm_256_ipadapter_FaceID.py", line 587, in set_ip_adapter
    attn_procs[name] = AttnProcessor()
  File "/root/miniconda3/envs/kolors/lib/python3.8/site-packages/kolors-0.1-py3.8.egg/kolors/models/ipa_faceid_plus/attention_processor.py", line 17, in __init__
    raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
ImportError: AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.
```